### PR TITLE
Add GitHub Pages site with RSS feed

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_site/
+.jekyll-cache/
+.sass-cache/

--- a/2019/2019-01-10.md
+++ b/2019/2019-01-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, January 10, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-02-14.md
+++ b/2019/2019-02-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, February 14, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-03-14.md
+++ b/2019/2019-03-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, March 14, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-04-25.md
+++ b/2019/2019-04-25.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, April 25, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-06-13.md
+++ b/2019/2019-06-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, June 13, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-07-11.md
+++ b/2019/2019-07-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, July 11, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-08-08.md
+++ b/2019/2019-08-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, August 8, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-09-26.md
+++ b/2019/2019-09-26.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, September 26, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-10-10.md
+++ b/2019/2019-10-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, October 10, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-11-21.md
+++ b/2019/2019-11-21.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, November 21, 2019
 
 The meeting was led by Frank Wiles.

--- a/2019/2019-12-17.md
+++ b/2019/2019-12-17.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, December 17, 2019
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-01-09.md
+++ b/2020/2020-01-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, January 9, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-02-13.md
+++ b/2020/2020-02-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, February 13, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-03-12.md
+++ b/2020/2020-03-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, March 12, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-04-09.md
+++ b/2020/2020-04-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, April 9, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-05-14.md
+++ b/2020/2020-05-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, May 14, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-06-11.md
+++ b/2020/2020-06-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, June 11, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-07-09.md
+++ b/2020/2020-07-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, July 9, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-08-13.md
+++ b/2020/2020-08-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, August 13, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-09-10.md
+++ b/2020/2020-09-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, September 10, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-10-08.md
+++ b/2020/2020-10-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, October 8, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-11-12.md
+++ b/2020/2020-11-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, November 12, 2020
 
 The meeting was led by Frank Wiles.

--- a/2020/2020-12-16.md
+++ b/2020/2020-12-16.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, December 16, 2020
 
 The meeting was led by Frank Wiles.

--- a/2021/2021-01-14.md
+++ b/2021/2021-01-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, January 14, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-02-11.md
+++ b/2021/2021-02-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, February 11, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-03-11.md
+++ b/2021/2021-03-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, March 11, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-04-08.md
+++ b/2021/2021-04-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, April 8, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-05-13.md
+++ b/2021/2021-05-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, May 13, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-06-17.md
+++ b/2021/2021-06-17.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, June 17, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-07-08.md
+++ b/2021/2021-07-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, July 8, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-08-11.md
+++ b/2021/2021-08-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, August 11, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-09-09.md
+++ b/2021/2021-09-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, September 9, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-10-14.md
+++ b/2021/2021-10-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, October 14, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-11-11.md
+++ b/2021/2021-11-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, November 11, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2021/2021-12-16.md
+++ b/2021/2021-12-16.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, December 16, 2021
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-01-13.md
+++ b/2022/2022-01-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, January 13, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-02-10.md
+++ b/2022/2022-02-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, February 10, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-03-10.md
+++ b/2022/2022-03-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, March 10, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-04-14.md
+++ b/2022/2022-04-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, April 14, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-05-12.md
+++ b/2022/2022-05-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, May 12, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-06-09.md
+++ b/2022/2022-06-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, June 9, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-07-14.md
+++ b/2022/2022-07-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, July 14, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-08-11.md
+++ b/2022/2022-08-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, August 11, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-09-08.md
+++ b/2022/2022-09-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, September 8, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-10-13.md
+++ b/2022/2022-10-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, October 13, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2022/2022-11-11.md
+++ b/2022/2022-11-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, November 11, 2022
 
 The meeting was led by Chaim Kirby.

--- a/2022/2022-12-08.md
+++ b/2022/2022-12-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, December 8, 2022
 
 The meeting was led by Anna Makarudze.

--- a/2023/2023-01-12.md
+++ b/2023/2023-01-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, January 12, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-02-08.md
+++ b/2023/2023-02-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, February 8, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-03-09.md
+++ b/2023/2023-03-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, March 9, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-04-13.md
+++ b/2023/2023-04-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, April 13, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-05-13.md
+++ b/2023/2023-05-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, May 13, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-06-08.md
+++ b/2023/2023-06-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, June 8, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-07-14.md
+++ b/2023/2023-07-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, July 14, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-09-14.md
+++ b/2023/2023-09-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, September 14, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-10-12.md
+++ b/2023/2023-10-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, October 12, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-11-09.md
+++ b/2023/2023-11-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, November 9, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2023/2023-12-14.md
+++ b/2023/2023-12-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, December 14, 2023
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-01-11.md
+++ b/2024/2024-01-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, January 11, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-02-08.md
+++ b/2024/2024-02-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, February 8, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-03-14.md
+++ b/2024/2024-03-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, March 14, 2024
 
 The meeting was led by Katie McLaughlin.

--- a/2024/2024-04-11.md
+++ b/2024/2024-04-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, April 11, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-05-16.md
+++ b/2024/2024-05-16.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, May 16, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-06-06.md
+++ b/2024/2024-06-06.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DjangoCon Europe 2025 proposals review meeting, June 6, 2024
 
 The meeting was led by Cagil Ulusahin Sonmez.

--- a/2024/2024-06-13.md
+++ b/2024/2024-06-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, June 13, 2024
 
 The meeting was led by Cagil Ulusahin Sonmez.

--- a/2024/2024-07-18.md
+++ b/2024/2024-07-18.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, July 18, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-08-08.md
+++ b/2024/2024-08-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, August 8, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-09-12.md
+++ b/2024/2024-09-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, September 12, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-10-10.md
+++ b/2024/2024-10-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, October 10, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-11-19.md
+++ b/2024/2024-11-19.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, November 19, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2024/2024-12-10.md
+++ b/2024/2024-12-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, December 10, 2024
 
 The meeting was led by Chaim Kirby.

--- a/2025/2025-01-09.md
+++ b/2025/2025-01-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, January 9, 2025
 
 The meeting was led by Thibaud Colas.

--- a/2025/2025-02-13.md
+++ b/2025/2025-02-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, February 13, 2025
 
 The meeting was led by Thibaud Colas.

--- a/2025/2025-03-13.md
+++ b/2025/2025-03-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, March 13, 2025
 
 The meeting was led by Thibaud Colas.

--- a/2025/2025-04-10.md
+++ b/2025/2025-04-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, April 10, 2025
 
 The meeting was led by Thibaud Colas.

--- a/2025/2025-05-08.md
+++ b/2025/2025-05-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 #  DSF Board monthly meeting, May 8, 2025
 
 This meeting was led by Thibaud Colas

--- a/2025/2025-06-12.md
+++ b/2025/2025-06-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, June 12, 2025
 
 This meeting was led by Jacob Kaplan-Moss

--- a/2025/2025-07-10.md
+++ b/2025/2025-07-10.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, July 10, 2025
 
 This meeting was led by Thibaud Colas

--- a/2025/2025-08-14.md
+++ b/2025/2025-08-14.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, August 14, 2025
 
 This meeting was led by Thibaud Colas

--- a/2025/2025-09-11.md
+++ b/2025/2025-09-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, September 11, 2025
 
 This meeting was led by Thibaud Colas

--- a/2025/2025-10-09.md
+++ b/2025/2025-10-09.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, October 9, 2025
 
 This meeting was led by Thibaud Colas

--- a/2025/2025-11-13.md
+++ b/2025/2025-11-13.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, November 13, 2025
 
 This meeting was led by Thibaud Colas

--- a/2025/2025-12-11.md
+++ b/2025/2025-12-11.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, December 11, 2025
 
 This meeting was led by Thibaud Colas

--- a/2025/template.md
+++ b/2025/template.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, {MONTH} {DAY}, 2025
 
 This meeting was led by Thibaud Colas

--- a/2026/2026-01-08.md
+++ b/2026/2026-01-08.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, January 8, 2026
 
 This meeting was led by Jeff Triplett.

--- a/2026/2026-02-12.md
+++ b/2026/2026-02-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, February 12, 2026
 
 This meeting was led by Jeff Triplett and Abigail Afi Gbadago.

--- a/2026/2026-03-12.md
+++ b/2026/2026-03-12.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, March 12, 2026
 
 This meeting was led by Jeff Triplett (Chair) and Abigail Afi Gbadago (Vice Chair).

--- a/2026/template.md
+++ b/2026/template.md
@@ -1,3 +1,6 @@
+---
+---
+
 # DSF Board monthly meeting, {MONTH} {DAY}, 2026
 
 This meeting was led by Jeff Triplett.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About
+
+This repository contains the meeting minutes of the Django Software Foundation (DSF) Board. It is a documentation-only repo with no build system, tests, or dependencies.
+
+## Structure
+
+- `template.md` — Base meeting minutes template with placeholder fields (`{MONTH}`, `{NAME}`, etc.)
+- `YYYY/template.md` — Year-specific template pre-filled with that year's board members and attendees
+- `YYYY/YYYY-MM-DD.md` — Individual meeting minutes, named by meeting date
+
+## Adding New Minutes
+
+1. Copy the current year's template (e.g., `2026/template.md`) to a new file named `YYYY-MM-DD.md` in the same directory
+2. Fill in the placeholders: date, meeting leader, attendance, apologies, finance balance, grants, members, business items, and action items
+3. Remove any template sections that don't apply (e.g., "Corporate members approved" if none were approved)
+
+## Adding a New Year
+
+1. Create a new directory for the year (e.g., `2027/`)
+2. Copy and update the previous year's template, adjusting board member names and default attendees for the new term
+
+## Conventions
+
+- Filenames use the meeting date: `YYYY-MM-DD.md`
+- Minutes follow a consistent markdown structure with H1 title, H2 sections (Finance, Grants approved, Individual/Corporate members approved, Ongoing business, New business, Action items), and H3 subsections
+- Confidential discussions are noted with: "Discussions under this section are confidential and have been omitted from the public minutes for this month."
+- The 2026+ template includes an "Apologies" field not present in the base `template.md`

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,18 @@
+title: DSF Board Meeting Minutes
+description: Meeting minutes of the Django Software Foundation Board
+url: https://django.github.io
+baseurl: /dsf-minutes
+
+exclude:
+  - README.md
+  - CLAUDE.md
+  - LICENSE
+  - justfile
+  - template.md
+  - "*/template.md"
+
+defaults:
+  - scope:
+      path: "20*/*.md"
+    values:
+      layout: page

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,11 @@
+<footer class="site-footer">
+  <div class="footer-inner">
+    <div class="footer-brand">&copy; {{ site.time | date: '%Y' }} Django Software Foundation</div>
+    <ul class="footer-links">
+      <li><a href="https://www.djangoproject.com/">djangoproject.com</a></li>
+      <li><a href="https://github.com/django/dsf-minutes">GitHub</a></li>
+      <li><a href="https://forum.djangoproject.com/">Forum</a></li>
+      <li><a href="{{ site.baseurl }}/feed.xml">RSS Feed</a></li>
+    </ul>
+  </div>
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,10 @@
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+<meta name="description" content="{{ site.description }}">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Plus+Jakarta+Sans:wght@600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/style.css">
+<link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ site.baseurl }}/feed.xml">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,18 @@
+<header class="site-header">
+  <div class="header-inner">
+    <a href="{{ site.baseurl }}/" class="site-brand">
+      <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect width="100" height="100" rx="16" fill="#092E20"/>
+        <text x="50" y="68" text-anchor="middle" fill="white" font-family="sans-serif" font-weight="bold" font-size="52">D</text>
+      </svg>
+      {{ site.title }}
+    </a>
+    <nav class="header-nav">
+      <a href="{{ site.baseurl }}/" {% if page.url == '/' %}class="active"{% endif %}>Minutes</a>
+      <a href="{{ site.baseurl }}/feed.xml" class="rss-link">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20C5 20 4 19 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1Z"/></svg>
+        RSS
+      </a>
+    </nav>
+  </div>
+</header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include head.html %}
+</head>
+<body>
+  {% include header.html %}
+  <main class="site-main">
+    {{ content }}
+  </main>
+  {% include footer.html %}
+</body>
+</html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include head.html %}
+</head>
+<body>
+  {% include header.html %}
+  <main class="site-main">
+    <div class="page-content">
+      <div class="gradient-bar"></div>
+      {{ content }}
+    </div>
+  </main>
+  {% include footer.html %}
+</body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,341 @@
+:root {
+  --django-dark: #092E20;
+  --django-green: #0C4B33;
+  --django-light-green: #44B78B;
+  --django-accent: #44B78B;
+  --bg: #fafaf9;
+  --bg-card: #ffffff;
+  --text: #1a1a2e;
+  --text-muted: #6b7280;
+  --border: #e5e7eb;
+  --font-display: 'Plus Jakarta Sans', system-ui, -apple-system, sans-serif;
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-body);
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.7;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--django-green);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+a:hover {
+  color: var(--django-light-green);
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.header-inner {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0.875rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.125rem;
+  color: var(--django-dark);
+  text-decoration: none;
+}
+
+.site-brand:hover {
+  color: var(--django-green);
+}
+
+.site-brand svg {
+  width: 30px;
+  height: 30px;
+}
+
+.header-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.header-nav a {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  padding: 0.25rem 0;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s;
+}
+
+.header-nav a:hover,
+.header-nav a.active {
+  color: var(--django-dark);
+  border-bottom-color: var(--django-light-green);
+}
+
+.rss-link {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--text-muted) !important;
+  font-size: 0.85rem;
+}
+
+.rss-link:hover {
+  color: #f97316 !important;
+}
+
+/* Main content */
+.site-main {
+  flex: 1;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  width: 100%;
+}
+
+/* Index page */
+.page-header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 2px solid var(--django-dark);
+}
+
+.page-header h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--django-dark);
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+.minutes-list {
+  list-style: none;
+}
+
+.minutes-list li {
+  border-bottom: 1px solid var(--border);
+}
+
+.minutes-list li:last-child {
+  border-bottom: none;
+}
+
+.minutes-list a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  color: var(--text);
+  font-weight: 500;
+  border-radius: 0.5rem;
+  transition: all 0.2s;
+}
+
+.minutes-list a:hover {
+  background: var(--bg-card);
+  color: var(--django-green);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  transform: translateX(4px);
+}
+
+.minutes-date {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+}
+
+.minutes-arrow {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  transition: transform 0.2s;
+}
+
+.minutes-list a:hover .minutes-arrow {
+  transform: translateX(4px);
+  color: var(--django-light-green);
+}
+
+/* Year groups */
+.year-group {
+  margin-bottom: 2rem;
+}
+
+.year-label {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--django-dark);
+  padding: 0.5rem 0;
+  margin-bottom: 0.25rem;
+  position: sticky;
+  top: 3.5rem;
+  background: var(--bg);
+  z-index: 10;
+}
+
+/* Page layout (individual minutes) */
+.page-content {
+  max-width: 48rem;
+}
+
+.page-content h1 {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--django-dark);
+  margin-bottom: 0.25rem;
+  line-height: 1.3;
+}
+
+.page-content h2 {
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--django-dark);
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 2px solid var(--django-light-green);
+}
+
+.page-content h3 {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--django-green);
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.page-content p {
+  margin-bottom: 1rem;
+}
+
+.page-content ul, .page-content ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+.page-content li {
+  margin-bottom: 0.35rem;
+}
+
+.page-content a {
+  color: var(--django-green);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.page-content a:hover {
+  color: var(--django-light-green);
+}
+
+.gradient-bar {
+  height: 3px;
+  background: linear-gradient(to right, var(--django-dark), var(--django-light-green));
+  border-radius: 2px;
+  margin: 1rem 0 1.5rem;
+}
+
+/* Footer */
+.site-footer {
+  border-top: 1px solid var(--border);
+  background: var(--django-dark);
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: auto;
+}
+
+.footer-inner {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer-brand {
+  font-family: var(--font-display);
+  font-weight: 600;
+  color: white;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+}
+
+.footer-links a {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+.footer-links a:hover {
+  color: var(--django-light-green);
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .page-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .header-inner {
+    padding: 0.75rem 1rem;
+  }
+
+  .site-main {
+    padding: 1.5rem 1rem;
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .minutes-list a {
+    padding: 0.75rem;
+  }
+}

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,23 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ site.title }}</title>
+  <link href="{{ site.url }}{{ site.baseurl }}/feed.xml" rel="self"/>
+  <link href="{{ site.url }}{{ site.baseurl }}/"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ site.url }}{{ site.baseurl }}/</id>
+  {% assign minutes = site.pages | sort: "name" | reverse %}
+  {% for page in minutes %}
+    {% if page.name != "template.md" and page.name != "index.md" and page.name != "feed.xml" and page.dir contains "20" %}
+  <entry>
+    <title>{{ page.name | replace: ".md", "" }}</title>
+    <link href="{{ site.url }}{{ site.baseurl }}{{ page.url }}"/>
+    <id>{{ site.url }}{{ site.baseurl }}{{ page.url }}</id>
+    <updated>{{ page.name | replace: ".md", "" }}T00:00:00Z</updated>
+    <content type="html">{{ page.content | xml_escape }}</content>
+  </entry>
+    {% endif %}
+  {% endfor %}
+</feed>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+---
+layout: default
+title: DSF Board Meeting Minutes
+---
+
+<div class="page-header">
+  <h1>DSF Board Meeting Minutes</h1>
+  <p>Public meeting minutes from the Django Software Foundation Board of Directors.</p>
+</div>
+
+{% assign minutes = site.pages | sort: "name" | reverse %}
+{% assign current_year = "" %}
+
+{% for page in minutes %}
+  {% if page.name != "template.md" and page.name != "index.md" and page.name != "index.html" and page.dir contains "20" %}
+    {% assign year = page.name | slice: 0, 4 %}
+    {% if year != current_year %}
+      {% if current_year != "" %}
+        </ul>
+      </div>
+      {% endif %}
+      <div class="year-group">
+        <div class="year-label">{{ year }}</div>
+        <ul class="minutes-list">
+      {% assign current_year = year %}
+    {% endif %}
+          <li>
+            <a href="{{ site.baseurl }}{{ page.url }}">
+              <span class="minutes-date">{{ page.name | replace: ".md", "" }}</span>
+              <span class="minutes-arrow">&rarr;</span>
+            </a>
+          </li>
+  {% endif %}
+{% endfor %}
+
+{% if current_year != "" %}
+        </ul>
+      </div>
+{% endif %}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+@default:
+    just --list
+
+# Start Jekyll development server
+up:
+    jekyll serve --watch
+
+# Build the Jekyll site
+build:
+    jekyll build


### PR DESCRIPTION
## Summary
- Adds Jekyll-based GitHub Pages support with a Django-branded theme (dark green color scheme, Plus Jakarta Sans/Inter fonts, sticky header with backdrop blur)
- Generates an Atom feed at `/feed.xml` so people can subscribe to new minutes notifications
- Adds an index page listing all minutes grouped by year in reverse chronological order
- Prepends empty YAML front matter (`---\n---`) to all 86 existing minutes files so Jekyll processes them

Related to #2